### PR TITLE
Add latest major upgrade infos

### DIFF
--- a/usr/share/mint-upgrade-info/elsie-major/info
+++ b/usr/share/mint-upgrade-info/elsie-major/info
@@ -1,0 +1,5 @@
+[general]
+target_name = "LMDE 6 Faye"
+editions = cinnamon
+architectures = i386, amd64
+link = https://blog.linuxmint.com/?p=4571

--- a/usr/share/mint-upgrade-info/virginia-major/info
+++ b/usr/share/mint-upgrade-info/virginia-major/info
@@ -1,0 +1,5 @@
+[general]
+target_name = "Linux Mint 22 Wilma"
+editions = cinnamon, mate, xfce
+architectures = amd64
+link = https://blog.linuxmint.com/?p=4732


### PR DESCRIPTION
Not adding the info for LMDE 4 -> 5 here because of https://github.com/linuxmint/mintupgrade/issues/78.
By the way, mintreport checks for the ubuntu/debian EOL date in /usr/share/linuxmint/mintreport/reports/080_release-eol/MintReportInfo.py. However, it should check for the real mint EOL date for LMDE releases, I think.